### PR TITLE
Add "begin" to folding start markers

### DIFF
--- a/syntaxes/fish.tmLanguage
+++ b/syntaxes/fish.tmLanguage
@@ -9,7 +9,7 @@
 	<key>firstLineMatch</key>
 	<string>^#!.*(fish)</string>
 	<key>foldingStartMarker</key>
-	<string>^\s*(function|while|if|switch|for)\s.*$</string>
+	<string>^\s*(function|while|if|switch|for|begin)\s.*$</string>
 	<key>foldingStopMarker</key>
 	<string>^\s*end\s*$</string>
 	<key>keyEquivalent</key>


### PR DESCRIPTION
`begin` is used to denote the start of a code block and should be usable to begin a foldable code block.

Here are the docs for the `begin` fish command:
https://fishshell.com/docs/current/commands.html#begin

Thanks for the excellent VSCode extension. 👍