### PR TITLE
* Updated tmLanguage to recognize \" and \'

### DIFF
--- a/syntaxes/fish.tmLanguage
+++ b/syntaxes/fish.tmLanguage
@@ -264,7 +264,7 @@
 					<key>comment</key>
 					<string>single character character escape sequences</string>
 					<key>match</key>
-					<string>\\(a|b|e|f|n|r|t|v|\s|\$|\\|\*|\?|~|\%|#|(|)|{|}|\[|\]|&lt;|&gt;|\^)</string>
+					<string>\\(\"|\'|a|b|e|f|n|r|t|v|\s|\$|\\|\*|\?|~|\%|#|(|)|{|}|\[|\]|&lt;|&gt;|\^)</string>
 					<key>name</key>
 					<string>constant.character.escape.single.fish</string>
 				</dict>


### PR DESCRIPTION
So, this line was breaking syntax highlighting in a fish script for me.

set version (egrep version pyproject.toml | cut -f2 -d= | string trim | string replace -a \\" "")

I updated tmLanguage so that the \" would be properly recognized.

**Be aware**, that I don't understand the format of the tmLanguage file, I just found what I thought was the right section and things worked after I updated it.

* Edit to escape the \\