### PR TITLE
Add "begin" to keywords

### DIFF
--- a/syntaxes/fish.tmLanguage
+++ b/syntaxes/fish.tmLanguage
@@ -120,7 +120,7 @@
 			<key>comment</key>
 			<string>control structures requiring an end</string>
 			<key>match</key>
-			<string>(?&lt;!\.)\b(function|while|if|else|switch|for|in|end)\b(?![?!])</string>
+			<string>(?&lt;!\.)\b(function|while|if|else|switch|for|begin|in|end)\b(?![?!])</string>
 			<key>name</key>
 			<string>keyword.control.fish</string>
 		</dict>


### PR DESCRIPTION
"begin" is a keyword that introduces a block, similar to parentheses in
bash. Since it affects syntax (requiring a matching "end" keyword), it
should be categorized as a keyword rather than a builtin.

## Before
![screenshot from 2019-02-07 21-15-54](https://user-images.githubusercontent.com/3344958/52460318-87de0b00-2b1e-11e9-8336-7f0d42832bfb.png)

## After
![screenshot from 2019-02-07 21-11-40](https://user-images.githubusercontent.com/3344958/52460321-8ad8fb80-2b1e-11e9-9c0c-e6515e24c860.png)
