### PR TITLE
Add shebang-based language detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
                 "extensions": [
                     ".fish"
                 ],
+                "firstLine": "^#!\\s*/usr/bin/env fish",
                 "configuration": "./language-configuration.json"
             }
         ],


### PR DESCRIPTION
This allows VSCode to automatically detect `fish` files with the following first line, which is the most portable way to invoke `fish`:

```
#!/usr/bin/env fish
```

Crucially, this works even if the file has no extension (common for scripts to be placed in the `$PATH`), and prevents VSCode from detecting them as another shell language (and highlighting lots of supposed errors, e.g. when a `shellcheck` extension is also installed). Instead, such files will have delightful `fish` syntax highlighting!